### PR TITLE
6.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+== 6.0.2 2024-06-18
+
+Fixes:
+* Fixed a crash where extremely long media files would cause the transcoder to fail with SystemStackError: stack level too deep
+
 == 6.0.1 2024-06-05
 
 Fixes:

--- a/lib/ffmpeg/timeout.rb
+++ b/lib/ffmpeg/timeout.rb
@@ -16,6 +16,7 @@ module FFMPEG
 
     def resume
       @paused = false
+      tick
     end
 
     def tick
@@ -42,12 +43,9 @@ module FFMPEG
     end
 
     def loop
-      if !@paused && Time.now - @last_tick >= @duration
-        @current_thread.raise(::Timeout::Error, @message || self.class.name)
-      else
-        sleep 0.1
-        loop
-      end
+      sleep 0.1 while @paused || Time.now - @last_tick <= @duration
+
+      @current_thread.raise(::Timeout::Error, @message || self.class.name)
     end
   end
 end

--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FFMPEG
-  VERSION = '6.0.1'
+  VERSION = '6.0.2'
 end


### PR DESCRIPTION
* Fixes a crash where extremely long media files would cause the transcoder to fail with SystemStackError: stack level too deep