### PR TITLE
fix: properly compose command args when metadata is missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+== 7.0.0-beta.5 2025-03-18
+
+Fixes:
+* Make sure the `CommandArgs` `compose` method does not raise an error if the metadata is missing.
+
 == 7.0.0-beta.4 2025-02-24
 
 Improvements:

--- a/lib/ffmpeg/command_args.rb
+++ b/lib/ffmpeg/command_args.rb
@@ -96,7 +96,7 @@ module FFMPEG
     # @param target_value [Integer, Float] The target frame rate.
     # @return [Numeric]
     def adjusted_frame_rate(target_value)
-      [media.frame_rate, target_value].min
+      [media.frame_rate, target_value].compact.min
     end
 
     # Returns the minimum of the current video bit rate and the target value.
@@ -123,7 +123,7 @@ module FFMPEG
 
     def min_bit_rate(*values)
       bit_rate =
-        values.map do |value|
+        values.compact.map do |value|
           next value if value.is_a?(Integer)
 
           unless value.is_a?(String)

--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FFMPEG
-  VERSION = '7.0.0-beta.4'
+  VERSION = '7.0.0-beta.5'
 end


### PR DESCRIPTION
Refs: ARC-9911