### PR TITLE
feat: optimize MPEG-DASH presets with better defaults

### DIFF
--- a/.github/workflows/ci.lint.yml
+++ b/.github/workflows/ci.lint.yml
@@ -15,10 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.4'
           bundler-cache: true
           rubygems: latest
 

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -30,17 +31,27 @@ jobs:
           bundler-cache: true
           rubygems: latest
 
+      - name: Cache FFMPEG Package
+        id: cache-ffmpeg
+        uses: actions/cache@v4
+        with:
+          path: /tmp/ffmpeg.tar.xz
+          key: ffmpeg-${{ matrix.ffmpeg-version }}-${{ runner.os }}.tar.xz
+
+      - name: Download FFMPEG Package
+        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
+        working-directory: /tmp
+        run: |
+          wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/${{ matrix.ffmpeg-download-path || 'old-releases' }}/ffmpeg-${{ matrix.ffmpeg-version }}-amd64-static.tar.xz
+
       - name: Install FFMPEG
         working-directory: /tmp
         run: |
-          sudo apt-get update
-          sudo apt-get install -y wget
-          wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/${{ matrix.ffmpeg-download-path || 'old-releases' }}/ffmpeg-${{ matrix.ffmpeg-version }}-amd64-static.tar.xz
           mkdir ffmpeg
           tar -xf ffmpeg.tar.xz --strip=1 -C ffmpeg
           sudo mv ffmpeg/ffmpeg /usr/local/bin/ffmpeg
           sudo mv ffmpeg/ffprobe /usr/local/bin/ffprobe
-          rm -rf ffmpeg.tar.xz ffmpeg
+          rm -rf ffmpeg
 
       - name: Run RSpec
         run: bundle exec rspec

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+== 7.0.0-beta.6 2025-03-25
+
+Improvements:
+* Increased default MPEG-DASH segment duration from 2 seconds to 4 seconds.
+* Removed the MPEG-DASH min_keyframe_interval and max_keyframe_interval options in
+  favor of calculating the optimal keyframe interval based on the
+  segment duration.
+
+Fixes:
+* Resolve byte sequence issues in progress reports.
+
 == 7.0.0-beta.5 2025-03-18
 
 Fixes:

--- a/lib/ffmpeg/io.rb
+++ b/lib/ffmpeg/io.rb
@@ -65,7 +65,7 @@ module FFMPEG
           block.call(buffer) unless buffer.empty?
           buffer = String.new
         else
-          buffer << char
+          buffer << FFMPEG::IO.encode!(char)
         end
       end
 

--- a/lib/ffmpeg/presets/dash.rb
+++ b/lib/ffmpeg/presets/dash.rb
@@ -14,33 +14,21 @@ module FFMPEG
       # @param filename [String] The filename format of the output.
       # @param metadata [Object] The metadata to associate with the preset.
       # @param segment_duration [Integer] The duration of each segment in seconds.
-      # @param min_keyframe_interval [Integer] The minimum keyframe interval in frames.
-      # @param max_keyframe_interval [Integer] The maximum keyframe interval in frames.
-      # @param scene_change_threshold [Integer] The scene change threshold.
       # @yield The block to execute to compose the command arguments.
       def initialize(
         name: nil,
         filename: nil,
         metadata: nil,
-        segment_duration: 2,
-        min_keyframe_interval: 48,
-        max_keyframe_interval: 48,
-        scene_change_threshold: 0,
+        segment_duration: 4,
         &
       )
         @segment_duration = segment_duration
-        @min_keyframe_interval = min_keyframe_interval
-        @max_keyframe_interval = max_keyframe_interval
-        @scene_change_threshold = scene_change_threshold
         preset = self
 
         super(name:, filename:, metadata:) do
           format_name 'dash'
           adaptation_sets 'id=0,streams=v id=1,streams=a'
           segment_duration preset.segment_duration
-          min_keyframe_interval preset.min_keyframe_interval
-          max_keyframe_interval preset.max_keyframe_interval
-          scene_change_threshold preset.scene_change_threshold
 
           muxing_flags '+faststart'
           map_chapters '-1'

--- a/lib/ffmpeg/presets/dash/aac.rb
+++ b/lib/ffmpeg/presets/dash/aac.rb
@@ -12,7 +12,7 @@ module FFMPEG
           name: 'DASH AAC 128k',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
+          segment_duration: 4,
           &
         )
           AAC.new(
@@ -29,7 +29,7 @@ module FFMPEG
           name: 'DASH AAC 192k',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
+          segment_duration: 4,
           &
         )
           AAC.new(
@@ -46,7 +46,7 @@ module FFMPEG
           name: 'DASH AAC 320k',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
+          segment_duration: 4,
           &
         )
           AAC.new(
@@ -73,7 +73,7 @@ module FFMPEG
           name: nil,
           filename: nil,
           metadata: nil,
-          segment_duration: 2,
+          segment_duration: 4,
           audio_bit_rate: '128k',
           &
         )

--- a/lib/ffmpeg/presets/dash/h264.rb
+++ b/lib/ffmpeg/presets/dash/h264.rb
@@ -16,10 +16,7 @@ module FFMPEG
           name: 'DASH H.264 360p',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
-          min_keyframe_interval: 48,
-          max_keyframe_interval: 48,
-          scene_change_threshold: 0,
+          segment_duration: 4,
           audio_bit_rate: '128k',
           frame_rate: 30,
           ld_frame_rate: 24,
@@ -30,9 +27,6 @@ module FFMPEG
             filename:,
             metadata:,
             segment_duration:,
-            min_keyframe_interval:,
-            max_keyframe_interval:,
-            scene_change_threshold:,
             h264_presets: [
               Presets.h264_360p(audio_bit_rate:, frame_rate:)
             ],
@@ -48,10 +42,7 @@ module FFMPEG
           name: 'DASH H.264 480p',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
-          min_keyframe_interval: 48,
-          max_keyframe_interval: 48,
-          scene_change_threshold: 0,
+          segment_duration: 4,
           audio_bit_rate: '128k',
           frame_rate: 30,
           ld_frame_rate: 24,
@@ -62,9 +53,6 @@ module FFMPEG
             filename:,
             metadata:,
             segment_duration:,
-            min_keyframe_interval:,
-            max_keyframe_interval:,
-            scene_change_threshold:,
             h264_presets: [
               Presets.h264_480p(audio_bit_rate:, frame_rate:),
               Presets.h264_360p(audio_bit_rate:, frame_rate:)
@@ -81,10 +69,7 @@ module FFMPEG
           name: 'DASH H.264 720p',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
-          min_keyframe_interval: 48,
-          max_keyframe_interval: 48,
-          scene_change_threshold: 0,
+          segment_duration: 4,
           audio_bit_rate: '128k',
           ld_frame_rate: 24,
           sd_frame_rate: 30,
@@ -96,9 +81,6 @@ module FFMPEG
             filename:,
             metadata:,
             segment_duration:,
-            min_keyframe_interval:,
-            max_keyframe_interval:,
-            scene_change_threshold:,
             h264_presets: [
               Presets.h264_720p(audio_bit_rate:, frame_rate: hd_frame_rate),
               Presets.h264_480p(audio_bit_rate:, frame_rate: sd_frame_rate),
@@ -116,10 +98,7 @@ module FFMPEG
           name: 'DASH H.264 1080p',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
-          min_keyframe_interval: 48,
-          max_keyframe_interval: 48,
-          scene_change_threshold: 0,
+          segment_duration: 4,
           audio_bit_rate: '128k',
           ld_frame_rate: 24,
           sd_frame_rate: 30,
@@ -131,9 +110,6 @@ module FFMPEG
             filename:,
             metadata:,
             segment_duration:,
-            min_keyframe_interval:,
-            max_keyframe_interval:,
-            scene_change_threshold:,
             h264_presets: [
               Presets.h264_1080p(audio_bit_rate:, frame_rate: hd_frame_rate),
               Presets.h264_720p(audio_bit_rate:, frame_rate: hd_frame_rate),
@@ -152,10 +128,7 @@ module FFMPEG
           name: 'DASH H.264 1440p',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
-          min_keyframe_interval: 48,
-          max_keyframe_interval: 48,
-          scene_change_threshold: 0,
+          segment_duration: 4,
           audio_bit_rate: '128k',
           ld_frame_rate: 24,
           sd_frame_rate: 30,
@@ -167,9 +140,6 @@ module FFMPEG
             filename:,
             metadata:,
             segment_duration:,
-            min_keyframe_interval:,
-            max_keyframe_interval:,
-            scene_change_threshold:,
             h264_presets: [
               Presets.h264_1440p(audio_bit_rate:, frame_rate: hd_frame_rate),
               Presets.h264_1080p(audio_bit_rate:, frame_rate: hd_frame_rate),
@@ -189,10 +159,7 @@ module FFMPEG
           name: 'DASH H.264 4K',
           filename: '%<basename>s.mpd',
           metadata: nil,
-          segment_duration: 2,
-          min_keyframe_interval: 48,
-          max_keyframe_interval: 48,
-          scene_change_threshold: 0,
+          segment_duration: 4,
           audio_bit_rate: '128k',
           ld_frame_rate: 24,
           sd_frame_rate: 30,
@@ -205,9 +172,6 @@ module FFMPEG
             filename:,
             metadata:,
             segment_duration:,
-            min_keyframe_interval:,
-            max_keyframe_interval:,
-            scene_change_threshold:,
             h264_presets: [
               Presets.h264_4k(audio_bit_rate:, frame_rate: uhd_frame_rate),
               Presets.h264_1440p(audio_bit_rate:, frame_rate: hd_frame_rate),
@@ -227,15 +191,12 @@ module FFMPEG
 
       # Preset to encode DASH H.264 video files.
       class H264 < DASH
-        attr_reader :h264_presets, :ld_h264_presets
+        attr_reader :scene_change_threshold, :h264_presets, :ld_h264_presets
 
         # @param name [String] The name of the preset.
         # @param filename [String] The filename format of the output.
         # @param metadata [Object] The metadata to associate with the preset.
         # @param segment_duration [Integer] The duration of each segment in seconds.
-        # @param min_keyframe_interval [Integer] The minimum keyframe interval in frames.
-        # @param max_keyframe_interval [Integer] The maximum keyframe interval in frames.
-        # @param scene_change_threshold [Integer] The scene change threshold.
         # @param h264_presets [Array<Presets::H264>] The H.264 presets to use for video streams and the audio stream.
         # @param ld_h264_presets [Array<Presets::H264>] The H.264 presets to use for low-definition video streams.
         # @yield The block to execute to compose the command arguments.
@@ -243,9 +204,7 @@ module FFMPEG
           name: nil,
           filename: nil,
           metadata: nil,
-          segment_duration: 2,
-          min_keyframe_interval: 48,
-          max_keyframe_interval: 48,
+          segment_duration: 4,
           scene_change_threshold: 0,
           h264_presets: [Presets.h264_1080p, Presets.h264_720p, Presets.h264_480p, Presets.h264_360p],
           ld_h264_presets: [Presets.h264_240p, Presets.h264_144p],
@@ -262,6 +221,7 @@ module FFMPEG
             end
           end
 
+          @scene_change_threshold = scene_change_threshold
           @h264_presets = h264_presets
           @ld_h264_presets = ld_h264_presets
           preset = self
@@ -271,10 +231,8 @@ module FFMPEG
             filename:,
             metadata:,
             segment_duration:,
-            min_keyframe_interval:,
-            max_keyframe_interval:,
-            scene_change_threshold:
           ) do
+            scene_change_threshold preset.scene_change_threshold
             video_codec_name 'libx264'
             audio_codec_name 'aac'
 
@@ -313,6 +271,7 @@ module FFMPEG
                   video_preset h264_preset.video_preset, stream_index: index
                   video_profile h264_preset.video_profile, stream_index: index
                   constant_rate_factor h264_preset.constant_rate_factor, stream_id: "v:#{index}"
+                  force_key_frames "expr:gte(t,n_forced*#{segment_duration})"
                   pixel_format h264_preset.pixel_format
                 end
               end

--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FFMPEG
-  VERSION = '7.0.0-beta.5'
+  VERSION = '7.0.0-beta.6'
 end


### PR DESCRIPTION
- Increased segment duration from 2 seconds to 4 seconds (this reduces
  the number of requests to media servers when using the default value).
- Removed the min_keyframe_interval and max_keyframe_interval options in
  favor of calculating the optimal keyframe interval based on the
  segment duration (every segment should start with a keyframe),
  additional keyframes can be generated with the scene_change_threshold
  option.
- Added download cache to CI to make it faster and more reliable.
- Upgraded the lint workflow to use Ruby 3.4.