### PR TITLE
feat!: add support for using zscale in the scale filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+== 7.0.0-beta.11 2025-04-10
+
+Improvements:
+* Better mimic the output of FFmpeg with the stream overview methods.
+* Added support for using zlib with the Scale filter.
+* Updated the H.264 presets to use zlib for scaling by default.
+
 == 7.0.0-beta.10 2025-04-08
 
 Fixes:

--- a/lib/ffmpeg/media.rb
+++ b/lib/ffmpeg/media.rb
@@ -190,6 +190,15 @@ module FFMPEG
       @default_video_stream = video_streams.find(&:default?) || video_streams.first
     end
 
+    # Whether the media is HDR (High Dynamic Range).
+    #
+    # @return [Boolean]
+    autoload def hdr?
+      default_video_stream&.color_primaries == 'bt2020' &&
+      default_video_stream&.color_space == 'bt2020nc' &&
+      %w[smpte2084 arib-std-b67].include?(default_video_stream&.color_transfer)
+    end
+
     # Whether the media is rotated (based on the default video stream).
     # (e.g. 90°, 180°, 270°)
     #
@@ -280,6 +289,13 @@ module FFMPEG
     # @return [String, nil]
     autoload def calculated_pixel_aspect_ratio
       default_video_stream&.calculated_pixel_aspect_ratio
+    end
+
+    # Returns the pixel format of the default video stream (if any).
+    #
+    # @return [String, nil]
+    autoload def pixel_format
+      default_video_stream&.pixel_format
     end
 
     # Returns the color range of the default video stream (if any).

--- a/lib/ffmpeg/presets/h264.rb
+++ b/lib/ffmpeg/presets/h264.rb
@@ -19,6 +19,7 @@ module FFMPEG
         frame_rate: 30,
         constant_rate_factor: 28,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -34,6 +35,7 @@ module FFMPEG
           pixel_format:,
           max_width: 256,
           max_height: 144,
+          zlib:,
           &
         )
       end
@@ -49,6 +51,7 @@ module FFMPEG
         frame_rate: 30,
         constant_rate_factor: 28,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -64,6 +67,7 @@ module FFMPEG
           pixel_format:,
           max_width: 426,
           max_height: 240,
+          zlib:,
           &
         )
       end
@@ -79,6 +83,7 @@ module FFMPEG
         frame_rate: 30,
         constant_rate_factor: 28,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -94,6 +99,7 @@ module FFMPEG
           pixel_format:,
           max_width: 640,
           max_height: 360,
+          zlib:,
           &
         )
       end
@@ -109,6 +115,7 @@ module FFMPEG
         frame_rate: 30,
         constant_rate_factor: 27,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -124,6 +131,7 @@ module FFMPEG
           pixel_format:,
           max_width: 854,
           max_height: 480,
+          zlib:,
           &
         )
       end
@@ -139,6 +147,7 @@ module FFMPEG
         frame_rate: 60,
         constant_rate_factor: 27,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -154,6 +163,7 @@ module FFMPEG
           pixel_format:,
           max_width: 1280,
           max_height: 720,
+          zlib:,
           &
         )
       end
@@ -169,6 +179,7 @@ module FFMPEG
         frame_rate: 60,
         constant_rate_factor: 27,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -184,6 +195,7 @@ module FFMPEG
           pixel_format:,
           max_width: 1920,
           max_height: 1080,
+          zlib:,
           &
         )
       end
@@ -199,6 +211,7 @@ module FFMPEG
         frame_rate: 60,
         constant_rate_factor: 26,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -214,6 +227,7 @@ module FFMPEG
           pixel_format:,
           max_width: 2560,
           max_height: 1440,
+          zlib:,
           &
         )
       end
@@ -229,6 +243,7 @@ module FFMPEG
         frame_rate: 60,
         constant_rate_factor: 26,
         pixel_format: 'yuv420p',
+        zlib: true,
         &
       )
         H264.new(
@@ -244,6 +259,7 @@ module FFMPEG
           pixel_format:,
           max_width: 3840,
           max_height: 2160,
+          zlib:,
           &
         )
       end
@@ -266,6 +282,7 @@ module FFMPEG
       # @param pixel_format [String] The pixel format to use.
       # @param max_width [Integer] The maximum width of the video.
       # @param max_height [Integer] The maximum height of the video.
+      # @param zlib [Boolean] Whether to use zlib for the scale filter.
       # @yield The block to execute to compose the command arguments.
       def initialize(
         name: nil,
@@ -280,6 +297,7 @@ module FFMPEG
         pixel_format: 'yuv420p',
         max_width: nil,
         max_height: nil,
+        zlib: true,
         &
       )
         if max_width && !max_width.is_a?(Numeric)
@@ -299,6 +317,7 @@ module FFMPEG
         @pixel_format = pixel_format
         @max_width = max_width
         @max_height = max_height
+        @zlib = zlib
         preset = self
 
         super(name:, filename:, metadata:) do
@@ -350,7 +369,7 @@ module FFMPEG
       def scale_filter(media)
         return unless @max_width || @max_height
 
-        Filters::Scale.contained(media, max_width: @max_width, max_height: @max_height)
+        Filters::Scale.contained(media, zlib: @zlib, max_width: @max_width, max_height: @max_height)
       end
     end
   end

--- a/lib/ffmpeg/stream.rb
+++ b/lib/ffmpeg/stream.rb
@@ -7,7 +7,7 @@ module FFMPEG
                 :id, :index, :profile, :tags,
                 :codec_name, :codec_long_name, :codec_tag, :codec_tag_string, :codec_type,
                 :coded_width, :coded_height, :sample_aspect_ratio, :display_aspect_ratio, :rotation,
-                :color_range, :color_space, :frame_rate,
+                :pixel_format, :color_range, :color_space, :color_primaries, :color_transfer, :field_order, :frame_rate,
                 :sample_rate, :sample_fmt, :channels, :channel_layout,
                 :start_time, :bit_rate, :duration, :frames, :overview
 
@@ -44,8 +44,12 @@ module FFMPEG
             &.abs
         end
 
+      @pixel_format = metadata[:pix_fmt]
       @color_range = metadata[:color_range]
-      @color_space = metadata[:pix_fmt] || metadata[:color_space]
+      @color_space = metadata[:color_space]
+      @color_primaries = metadata[:color_primaries]
+      @color_transfer = metadata[:color_transfer]
+      @field_order = metadata[:field_order]
       unless metadata[:avg_frame_rate].nil? || metadata[:avg_frame_rate] == '0/0'
         @frame_rate = Rational(metadata[:avg_frame_rate])
       end
@@ -64,7 +68,11 @@ module FFMPEG
         @overview = "#{codec_name} " \
                     "(#{profile}) " \
                     "(#{codec_tag_string} / #{codec_tag}), " \
-                    "#{color_space}, #{resolution} " \
+                    "#{pixel_format}" \
+                    "(#{color_range || 'unknown'}, " \
+                    "#{color_space || 'unknown'}/#{color_transfer || 'unknown'}/#{color_primaries || 'unknown'}, " \
+                    "#{field_order || 'unknown'}), " \
+                    "#{resolution} " \
                     "[SAR #{sample_aspect_ratio} DAR #{display_aspect_ratio}]"
       elsif audio?
         @overview = "#{codec_name} " \

--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FFMPEG
-  VERSION = '7.0.0-beta.10'
+  VERSION = '7.0.0-beta.11'
 end

--- a/spec/ffmpeg/filters/scale_spec.rb
+++ b/spec/ffmpeg/filters/scale_spec.rb
@@ -71,25 +71,15 @@ module FFMPEG
           expect { described_class.new(height: '1') }.not_to raise_error
           expect { described_class.new(height: []) }.to raise_error(ArgumentError)
         end
-
-        it 'raises ArgumentError if force_original_aspect_ratio is not string' do
-          expect { described_class.new(force_original_aspect_ratio: '1') }.not_to raise_error
-          expect { described_class.new(force_original_aspect_ratio: 1) }.to raise_error(ArgumentError)
-        end
-
-        it 'raises ArgumentError if flags is not an array' do
-          expect { described_class.new(flags: []) }.not_to raise_error
-          expect { described_class.new(flags: '1') }.to raise_error(ArgumentError)
-        end
       end
 
       describe '#to_s' do
         it 'returns the filter as a string' do
-          filter = described_class.new(width: 640, height: 480, force_original_aspect_ratio: 'decrease')
-          expect(filter.to_s).to eq('scale=w=640:h=480:force_original_aspect_ratio=decrease')
+          filter = described_class.new(zlib: true, width: 640, height: 480, algorithm: 'lanczos')
+          expect(filter.to_s).to eq('zscale=w=640:h=480:f=lanczos')
 
-          filter = described_class.new(width: 'iw/2', height: 'ih/2', force_original_aspect_ratio: 'increase')
-          expect(filter.to_s).to eq('scale=w=iw/2:h=ih/2:force_original_aspect_ratio=increase')
+          filter = described_class.new(width: 'iw/2', height: 'ih/2', algorithm: 'lanczos')
+          expect(filter.to_s).to eq('scale=w=iw/2:h=ih/2:flags=lanczos')
 
           filter = described_class.new(width: -2)
           expect(filter.to_s).to eq('scale=w=-2')

--- a/spec/ffmpeg/media_spec.rb
+++ b/spec/ffmpeg/media_spec.rb
@@ -447,7 +447,8 @@ module FFMPEG
     {
       calculated_pixel_aspect_ratio: Rational(1),
       color_range: 'pc',
-      color_space: 'yuvj420p',
+      pixel_format: 'yuvj420p',
+      color_space: 'bt709',
       frame_rate: Rational(60 / 1),
       frames: 213,
       video_index: 0,
@@ -456,7 +457,10 @@ module FFMPEG
       video_profile: 'High',
       video_codec_name: 'h264',
       video_bit_rate: 41_401_600,
-      video_overview: 'h264 (High) (avc1 / 0x31637661), yuvj420p, 3840x2160 [SAR 1:1 DAR 16:9]',
+      # rubocop:disable Layout/LineLength
+      video_overview:
+        %r{h264 \(High\) \(avc1 / 0x31637661\), yuvj420p\(pc, bt709/bt709/bt709, (progressive|unknown)\), 3840x2160 \[SAR 1:1 DAR 16:9\]},
+      # rubocop:enable Layout/LineLength
       video_tags: {
         encoder: 'Lavc61.19.100 libx264',
         handler_name: 'VideoHandle',
@@ -466,7 +470,11 @@ module FFMPEG
     }.each do |method, value|
       describe "##{method}" do
         it "returns the #{method.to_s.gsub(/^video_/, '').gsub('_', ' ')} of the default video stream" do
-          expect(subject.public_send(method)).to eq(value)
+          if value.is_a?(Regexp)
+            expect(subject.public_send(method)).to match(value)
+          else
+            expect(subject.public_send(method)).to eq(value)
+          end
         end
       end
     end


### PR DESCRIPTION
Improvements:
* Better mimic the output of FFmpeg with the stream overview methods.
* Added support for using zlib with the Scale filter.
* Updated the H.264 presets to use zlib for scaling by default.