### PR TITLE
fix: handle missing audio bitrate in some muxers

### DIFF
--- a/lib/ffmpeg/command_args.rb
+++ b/lib/ffmpeg/command_args.rb
@@ -130,8 +130,10 @@ module FFMPEG
 
     def min_bit_rate(*values)
       bit_rate =
-        values.compact.map do |value|
-          next value if value.is_a?(Integer)
+        values.filter_map do |value|
+          # Some muxers (webm) might not expose birate under certain conditions
+          next false if value.nil?
+          next (value.positive? ? value : false) if value.is_a?(Integer)
 
           unless value.is_a?(String)
             raise ArgumentError,

--- a/lib/ffmpeg/media.rb
+++ b/lib/ffmpeg/media.rb
@@ -195,8 +195,8 @@ module FFMPEG
     # @return [Boolean]
     autoload def hdr?
       default_video_stream&.color_primaries == 'bt2020' &&
-      default_video_stream&.color_space == 'bt2020nc' &&
-      %w[smpte2084 arib-std-b67].include?(default_video_stream&.color_transfer)
+        default_video_stream&.color_space == 'bt2020nc' &&
+        %w[smpte2084 arib-std-b67].include?(default_video_stream&.color_transfer)
     end
 
     # Whether the media is rotated (based on the default video stream).

--- a/spec/ffmpeg/command_args_spec.rb
+++ b/spec/ffmpeg/command_args_spec.rb
@@ -96,6 +96,14 @@ module FFMPEG
           expect(args.to_a).to eq(%w[])
         end
       end
+
+      context 'when the reported media bitrate is 0' do
+        it 'returns the requested bitrate' do
+          media = instance_double(Media, video_bit_rate: 0)
+          args = CommandArgs.compose(media) { min_video_bit_rate '2M' }
+          expect(args.to_a).to eq(%w[-minrate 2000k])
+        end
+      end
     end
 
     describe '#max_video_bit_rate' do


### PR DESCRIPTION
I don't know the precise conditions in which it happens, but I've multiple webm files where the audio bitrate isn't stored in the headers, in which case ffmpeg returns a bitrate of 0.
In that case, the bitrate used during transcode is set to 0, using the default for the codec instead of the user provided value.